### PR TITLE
Update reporting of status

### DIFF
--- a/clients/Heatmiser.js
+++ b/clients/Heatmiser.js
@@ -19,8 +19,8 @@ class Heatmiser {
 
         let device = await this.device();
 
-        this._logger.debug(device.status);
-        return device.status === 'on';
+        this._logger.debug(device.contactable);
+        return device.contactable === true;
     }
 
     async device() {
@@ -30,7 +30,7 @@ class Heatmiser {
             contactable: data.dcb.device_on,
             currentTemperature: data.dcb.built_in_air_temp,
             targetTemperature: data.dcb.set_room_temp,
-            status: data.dcb.device_on ? 'on' : 'off'
+            status: data.dcb.heating_on ? 'on' : 'off'
         };
         this._logger.debug(JSON.stringify(info));
         return info;


### PR DESCRIPTION
Previous version reported heating as being on when it is off. This is because data.dcb.device_on was being used to identify the heating status when it should be data.dcb.heating_on. Changes made to device() and online() to fix this.

You might consider this to be a feature rather than a bug! In determineIfHolding(), the line messages.push(`The heating is${qualifier} on.`); in particular will now give the correct message from my perspective