### PR TITLE
Correct reporting of heating on status

### DIFF
--- a/clients/Heatmiser.js
+++ b/clients/Heatmiser.js
@@ -19,8 +19,8 @@ class Heatmiser {
 
         let device = await this.device();
 
-        this._logger.debug(device.status);
-        return device.status === 'on';
+        this._logger.debug(device.contactable);
+        return device.contactable === true;
     }
 
     async device() {

--- a/clients/Heatmiser.js
+++ b/clients/Heatmiser.js
@@ -30,7 +30,7 @@ class Heatmiser {
             contactable: data.dcb.device_on,
             currentTemperature: data.dcb.built_in_air_temp,
             targetTemperature: data.dcb.set_room_temp,
-            status: data.dcb.device_on ? 'on' : 'off'
+            status: data.dcb.heating_on ? 'on' : 'off'
         };
         this._logger.debug(JSON.stringify(info));
         return info;


### PR DESCRIPTION
The previous version would report that the heating was on when it wasn't (in smartheat-core/core/ThermostatService.js - determineIfHolding() - messages.push(`The heating is${qualifier} on.`); ). This is because data.dcb.device_on was being used in device() to determine if the heating is on, when data.dcb.heating_on should be used.